### PR TITLE
Add `check` workflow, fix `clippy` warnings, add `color-name` feature

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,119 @@
+name: Check
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/check.yml"
+      - "**/Cargo.*"
+      - "crates/**"
+      - "examples/**"
+      - "src/**"
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - ".github/workflows/check.yml"
+      - "**/Cargo.*"
+      - "crates/**"
+      - "examples/**"
+      - "src/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.ref }}-check
+  cancel-in-progress: true
+
+env:
+  CARGO_CACHE_PATH: |
+    ~/.cargo/bin/
+    ~/.cargo/registry/index/
+    ~/.cargo/registry/cache/
+    ~/.cargo/git/db/
+    target/
+
+jobs:
+  msrv:
+    name: Minimum supported Rust version
+    runs-on:
+      - self-hosted
+      - small
+      - rootless-dind-ubuntu
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@1.70.0
+        id: toolchain
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.CARGO_CACHE_PATH }}
+          key: ${{ runner.os }}-cargo-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-${{ steps.toolchain.outputs.cachekey }}-
+      - run: cargo check --workspace --all-targets --all-features
+
+  deny:
+    name: Deny
+    runs-on:
+      - self-hosted
+      - small
+      - rootless-dind-ubuntu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        id: toolchain
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.CARGO_CACHE_PATH }}
+          key: ${{ runner.os }}-cargo-deny-${{ steps.toolchain.outputs.cachekey }}
+          restore-keys: ${{ runner.os }}-cargo-deny-
+      - run: cargo install --locked cargo-deny || true
+      - run: cargo deny --workspace --all-features check --show-stats
+
+  rustfmt:
+    name: Rustfmt
+    runs-on:
+      - self-hosted
+      - small
+      - rootless-dind-ubuntu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  check:
+    name: Check
+    runs-on:
+      - self-hosted
+      - small
+      - rootless-dind-ubuntu
+    strategy:
+      fail-fast: false
+      matrix:
+        features: ["--all-features", "--no-default-features"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+        id: toolchain
+        with:
+          components: clippy
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.CARGO_CACHE_PATH }}
+          key: ${{ runner.os }}-cargo-check-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-check-${{ steps.toolchain.outputs.cachekey }}-
+      - name: Check
+        run: cargo check --workspace --all-targets ${{ matrix.features }}
+      - name: Test
+        run: cargo test --workspace --all-targets ${{ matrix.features }}
+      - name: Doctest
+        run: cargo test --workspace --doc ${{ matrix.features }}
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets ${{ matrix.features }} -- -Dwarnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/nvtx-sys"]
 version = "0.1.0"
 authors = ["Voltron Data"]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.70.0"
 description = "NVIDIA NVTX bindings for Rust"
 repository = "https://github.com/voltrondata/nvtx-rs"
 readme = "README.md"
@@ -22,8 +22,13 @@ description.workspace = true
 repository.workspace = true
 readme.workspace = true
 publish.workspace = true
+license.workspace = true
+
+[features]
+default = ["color-name"]
+color-name = ["dep:color-name"]
 
 [dependencies]
+color-name = { version = "1.1.0", optional = true }
 nvtx-sys = { path = "crates/nvtx-sys" }
-color-name = "1.1.0"
 widestring = "1.0.2"

--- a/crates/nvtx-sys/Cargo.toml
+++ b/crates/nvtx-sys/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
 name = "nvtx-sys"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description.workspace = true
+repository.workspace = true
+readme.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [build-dependencies]
 bindgen = "0.69.4"

--- a/crates/nvtx-sys/build.rs
+++ b/crates/nvtx-sys/build.rs
@@ -1,5 +1,7 @@
-use std::env;
-use std::path::{Path, PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 fn main() {
     cc::Build::new()
@@ -17,7 +19,9 @@ fn main() {
         .allowlist_recursively(false)
         .generate_cstr(true)
         .default_alias_style(bindgen::AliasVariation::TypeAlias)
-        .default_enum_style(bindgen::EnumVariation::Rust { non_exhaustive: false })
+        .default_enum_style(bindgen::EnumVariation::Rust {
+            non_exhaustive: false,
+        })
         .wrap_unsafe_ops(true)
         .must_use_type("nvtxRangeId_t")
         .must_use_type("nvtxStringHandle_t")

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,11 @@
+[licenses]
+allow-osi-fsf-free = "both"
+copyleft = "deny"
+default = "deny"
+allow = ["Unicode-DFS-2016", "CC0-1.0", "OpenSSL"]
+private = { ignore = true }
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,5 @@
 use crate::TypeValueEncodable;
+#[cfg(feature = "color-name")]
 pub use color_name::colors::*;
 
 /// Represents a color in use for controlling appearance within NSight Systems

--- a/src/domain/event_argument.rs
+++ b/src/domain/event_argument.rs
@@ -28,7 +28,7 @@ impl<'a> From<EventAttributes<'a>> for EventArgument<'a> {
                 payload: None,
                 message: Some(Message::Unicode(s)),
             } => EventArgument::Unicode(s),
-            attr => EventArgument::EventAttribute(attr.into()),
+            attr => EventArgument::EventAttribute(attr),
         }
     }
 }

--- a/src/domain/identifier.rs
+++ b/src/domain/identifier.rs
@@ -20,26 +20,26 @@ impl TypeValueEncodable for Identifier {
         match self {
             Identifier::Pointer(p) => (
                 nvtx_sys::ffi::nvtxResourceGenericType_t::NVTX_RESOURCE_TYPE_GENERIC_POINTER as u32,
-                Self::Value { pValue: p.clone() },
+                Self::Value { pValue: *p },
             ),
             Identifier::Handle(h) => (
                 nvtx_sys::ffi::nvtxResourceGenericType_t::NVTX_RESOURCE_TYPE_GENERIC_HANDLE as u32,
                 Self::Value {
-                    ullValue: h.clone(),
+                    ullValue: *h,
                 },
             ),
             Identifier::NativeThread(t) => (
                 nvtx_sys::ffi::nvtxResourceGenericType_t::NVTX_RESOURCE_TYPE_GENERIC_THREAD_NATIVE
                     as u32,
                 Self::Value {
-                    ullValue: t.clone(),
+                    ullValue: *t,
                 },
             ),
             Identifier::PosixThread(t) => (
                 nvtx_sys::ffi::nvtxResourceGenericType_t::NVTX_RESOURCE_TYPE_GENERIC_THREAD_POSIX
                     as u32,
                 Self::Value {
-                    ullValue: t.clone(),
+                    ullValue: *t,
                 },
             ),
         }

--- a/src/event_argument.rs
+++ b/src/event_argument.rs
@@ -28,7 +28,7 @@ impl From<EventAttributes> for EventArgument {
                 payload: None,
                 message: Some(Message::Unicode(s)),
             } => EventArgument::Unicode(s),
-            attr => EventArgument::EventAttribute(attr.into()),
+            attr => EventArgument::EventAttribute(attr),
         }
     }
 }

--- a/src/range.rs
+++ b/src/range.rs
@@ -23,7 +23,7 @@ impl Range {
     }
 }
 
-impl<'a> Drop for Range {
+impl Drop for Range {
     fn drop(&mut self) {
         unsafe { nvtx_sys::ffi::nvtxRangeEnd(self.id) }
     }


### PR DESCRIPTION
Adds a `check` workflow which runs on pushes to `main` and `PRs` to:
- check MSRV (lowered this to 1.70.0)
- run [cargo deny](https://github.com/EmbarkStudios/cargo-deny) - added `deny.toml` config.
- check formatting with `rustfmt`
- build, test and lint

Fixed some Clippy warnings.

Added a `color-name` feature - enabled by default.