### PR TITLE
Refactor: hoist common code and simplify builder usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -79,10 +79,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8cabd7573f60c1096a1e2bd82b2dc03a8063e607c698e15189a476c3541d65c"
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "gettid"
@@ -99,6 +171,12 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "itertools"
@@ -171,9 +249,10 @@ dependencies = [
 
 [[package]]
 name = "nvtx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "color-name",
+ "derive_builder",
  "gettid",
  "libc",
  "nvtx-sys",
@@ -185,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "nvtx-sys"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -194,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "overload"
@@ -217,7 +296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -295,6 +374,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,7 +430,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.57",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/nvtx-sys"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Voltron Data"]
 edition = "2021"
 rust-version = "1.77.0"
@@ -40,6 +40,7 @@ tracing = ["dep:tracing-core", "dep:tracing-subscriber", "dep:color-name"]
 
 [dependencies]
 color-name = { version = "1.1.0", optional = true }
+derive_builder = "0.12"
 gettid = { version = "0.1.3", optional = true }
 nvtx-sys = { path = "crates/nvtx-sys" }
 tracing-core = { version = "0.1.34", optional = true }

--- a/examples/range.rs
+++ b/examples/range.rs
@@ -8,7 +8,7 @@ fn main() {
     for i in 1..=10 {
         {
             let _rng = nvtx::LocalRange::new(
-                nvtx::EventAttributesBuilder::default()
+                nvtx::EventAttributes::builder()
                     .color(nvtx::color::cornflowerblue)
                     .message(format!("Iteration Number {i}"))
                     .payload(i)
@@ -17,7 +17,7 @@ fn main() {
             for j in 1..=i {
                 {
                     let _r = nvtx::LocalRange::new(
-                        nvtx::EventAttributesBuilder::default()
+                        nvtx::EventAttributes::builder()
                             .color(nvtx::color::beige)
                             .payload(j)
                             .message("Inner")

--- a/examples/range_start_end.rs
+++ b/examples/range_start_end.rs
@@ -4,7 +4,7 @@ fn main() {
     // we must hold ranges with a proper name
     // _ will not work since drop() is called immediately
     let mut app = Some(nvtx::Range::new(
-        nvtx::EventAttributesBuilder::default()
+        nvtx::EventAttributes::builder()
             .color(nvtx::color::salmon)
             .message("Start 🦀")
             .build(),
@@ -13,7 +13,7 @@ fn main() {
     for i in 10..=20 {
         {
             let mut iter = Some(nvtx::Range::new(
-                nvtx::EventAttributesBuilder::default()
+                nvtx::EventAttributes::builder()
                     .color(nvtx::color::cornflowerblue)
                     .message(format!("Iteration Number {i}"))
                     .payload(i)
@@ -22,7 +22,7 @@ fn main() {
             for j in 1..=i {
                 {
                     let inner = nvtx::Range::new(
-                        nvtx::EventAttributesBuilder::default()
+                        nvtx::EventAttributes::builder()
                             .color(nvtx::color::beige)
                             .payload(j)
                             .message("Inner")

--- a/src/category.rs
+++ b/src/category.rs
@@ -1,4 +1,4 @@
-use crate::Str;
+use crate::{common::CategoryEncodable, Str};
 use std::sync::atomic::{AtomicU32, Ordering};
 
 /// Represents a category for use with mark and range grouping.
@@ -27,14 +27,27 @@ impl Category {
     }
 }
 
+impl CategoryEncodable for Category {
+    fn encode_id(&self) -> u32 {
+        self.id
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::TestUtils;
 
     #[test]
-    fn test() {
+    fn test_unique_categories() {
         let cat1 = Category::new("category 1");
         let cat2 = Category::new("category 1");
         assert_ne!(cat1, cat2);
+    }
+
+    #[test]
+    fn test_category_encoding() {
+        let cat = Category::new("test category");
+        TestUtils::assert_category_encoding(&cat, cat.id);
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -129,7 +129,7 @@ impl TypeValueEncodable for Color {
 
 #[cfg(test)]
 mod tests {
-    use crate::TypeValueEncodable;
+    use crate::{common::TestUtils, TypeValueEncodable};
 
     use super::Color;
 
@@ -196,9 +196,7 @@ mod tests {
     fn encode() {
         let (r, g, b, a) = (0x12, 0x34, 0x56, 0x78);
         let color = Color::new(r, g, b, a);
-        let (t, v) = color.encode();
-        assert_eq!(t, nvtx_sys::ColorType::NVTX_COLOR_ARGB);
-        assert_eq!(v, u32::from_be_bytes([a, r, g, b]));
+        TestUtils::assert_color_encoding(&color, r, g, b, a);
     }
 
     #[test]

--- a/src/common/event_argument.rs
+++ b/src/common/event_argument.rs
@@ -1,0 +1,30 @@
+/// Generic event argument type that can be used in both global and domain contexts
+#[derive(Debug, Clone)]
+pub enum GenericEventArgument<M, A> {
+    /// Holds a Message.
+    Message(M),
+    /// Holds an EventAttributes.
+    Attributes(A),
+}
+
+impl<M, A> GenericEventArgument<M, A> {
+    /// Create a new event argument from a message
+    pub fn message(message: M) -> Self {
+        Self::Message(message)
+    }
+
+    /// Create a new event argument from attributes
+    pub fn attributes(attributes: A) -> Self {
+        Self::Attributes(attributes)
+    }
+
+    /// Check if this is a message variant
+    pub fn is_message(&self) -> bool {
+        matches!(self, Self::Message(_))
+    }
+
+    /// Check if this is an attributes variant
+    pub fn is_attributes(&self) -> bool {
+        matches!(self, Self::Attributes(_))
+    }
+}

--- a/src/common/event_attributes.rs
+++ b/src/common/event_attributes.rs
@@ -1,0 +1,90 @@
+use crate::{Color, Payload, TypeValueEncodable};
+use derive_builder::Builder;
+
+/// Generic event attributes that can be used in both global and domain contexts.
+///
+/// This struct holds optional fields for category, color, message, and payload.
+/// It is used to describe the attributes of an NVTX event.
+#[derive(Default, Debug, Clone, Builder)]
+#[builder(pattern = "owned", derive(Clone), build_fn(skip))]
+pub struct GenericEventAttributes<C, M> {
+    #[builder(setter(into, strip_option))]
+    pub category: Option<C>,
+    #[builder(setter(into, strip_option))]
+    pub color: Option<Color>,
+    #[builder(setter(into, strip_option))]
+    pub message: Option<M>,
+    #[builder(setter(into, strip_option))]
+    pub payload: Option<Payload>,
+}
+
+impl<C, M> GenericEventAttributesBuilder<C, M> {
+    /// Build the event attributes, allowing all fields to be optional.
+    pub fn build(self) -> GenericEventAttributes<C, M> {
+        GenericEventAttributes {
+            category: self.category.flatten(),
+            color: self.color.flatten(),
+            message: self.message.flatten(),
+            payload: self.payload.flatten(),
+        }
+    }
+}
+
+/// Common encoding implementation for event attributes.
+///
+/// This function encodes the event attributes into the NVTX FFI struct.
+/// Used internally by both global and domain event attributes.
+///
+/// # Parameters
+/// - `category`: Optional category value
+/// - `color`: Optional color value
+/// - `message`: Optional message value
+/// - `payload`: Optional payload value
+pub fn encode_event_attributes<C, M>(
+    category: &Option<C>,
+    color: &Option<Color>,
+    message: &Option<M>,
+    payload: &Option<Payload>,
+) -> nvtx_sys::EventAttributes
+where
+    C: CategoryEncodable,
+    M: TypeValueEncodable<Type = nvtx_sys::MessageType, Value = nvtx_sys::MessageValue>,
+{
+    let (color_type, color_value) = color
+        .as_ref()
+        .map(Color::encode)
+        .unwrap_or_else(Color::default_encoding);
+    let (payload_type, payload_value) = payload
+        .as_ref()
+        .map(Payload::encode)
+        .unwrap_or_else(Payload::default_encoding);
+    let cat = category
+        .as_ref()
+        .map(CategoryEncodable::encode_id)
+        .unwrap_or(0);
+    let (message_type, message_value) = message
+        .as_ref()
+        .map(M::encode)
+        .unwrap_or_else(M::default_encoding);
+
+    nvtx_sys::EventAttributes {
+        version: nvtx_sys::NVTX_VERSION as u16,
+        size: 48,
+        category: cat,
+        colorType: color_type as i32,
+        color: color_value,
+        payloadType: payload_type as i32,
+        reserved0: 0,
+        payload: payload_value,
+        messageType: message_type as i32,
+        message: message_value,
+    }
+}
+
+/// Trait for encoding category IDs.
+///
+/// Used to abstract over global and domain category types.
+pub trait CategoryEncodable {
+    /// Encode the category as a u32 ID for NVTX.
+    fn encode_id(&self) -> u32;
+}

--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -1,0 +1,109 @@
+use crate::{Str, TypeValueEncodable};
+use std::ffi::{CStr, CString};
+use widestring::{WideCStr, WideCString};
+
+/// Generic message type that can be used in both global and domain contexts
+#[derive(Debug, Clone)]
+pub enum GenericMessage<T = ()> {
+    /// An owned ASCII string.
+    Ascii(CString),
+    /// An owned Unicode string.
+    Unicode(WideCString),
+    /// A registered string handle (only available in domain context).
+    Registered(T),
+}
+
+impl<T> GenericMessage<T> {
+    /// Create an ASCII message
+    pub fn ascii(s: CString) -> Self {
+        Self::Ascii(s)
+    }
+
+    /// Create a Unicode message
+    pub fn unicode(s: WideCString) -> Self {
+        Self::Unicode(s)
+    }
+
+    /// Create a registered message (domain context only)
+    pub fn registered(r: T) -> Self {
+        Self::Registered(r)
+    }
+}
+
+impl<T> From<Str> for GenericMessage<T> {
+    fn from(value: Str) -> Self {
+        match value {
+            Str::Ascii(s) => Self::Ascii(s),
+            Str::Unicode(s) => Self::Unicode(s),
+        }
+    }
+}
+
+impl<T> From<String> for GenericMessage<T> {
+    fn from(value: String) -> Self {
+        GenericMessage::from(Str::from(value))
+    }
+}
+
+impl<T> From<&str> for GenericMessage<T> {
+    fn from(value: &str) -> Self {
+        GenericMessage::from(Str::from(value))
+    }
+}
+
+impl<T> From<CString> for GenericMessage<T> {
+    fn from(value: CString) -> Self {
+        Self::Ascii(value)
+    }
+}
+
+impl<T> From<WideCString> for GenericMessage<T> {
+    fn from(value: WideCString) -> Self {
+        Self::Unicode(value)
+    }
+}
+
+impl<T> From<&CStr> for GenericMessage<T> {
+    fn from(value: &CStr) -> Self {
+        Self::Ascii(value.to_owned())
+    }
+}
+
+impl<T> From<&WideCStr> for GenericMessage<T> {
+    fn from(value: &WideCStr) -> Self {
+        Self::Unicode(value.to_owned())
+    }
+}
+
+impl<T> TypeValueEncodable for GenericMessage<T>
+where
+    T: TypeValueEncodable<Type = nvtx_sys::MessageType, Value = nvtx_sys::MessageValue>,
+{
+    type Type = nvtx_sys::MessageType;
+    type Value = nvtx_sys::MessageValue;
+
+    fn encode(&self) -> (Self::Type, Self::Value) {
+        match self {
+            GenericMessage::Ascii(s) => (
+                Self::Type::NVTX_MESSAGE_TYPE_ASCII,
+                Self::Value { ascii: s.as_ptr() },
+            ),
+            GenericMessage::Unicode(s) => (
+                Self::Type::NVTX_MESSAGE_TYPE_UNICODE,
+                Self::Value {
+                    unicode: s.as_ptr().cast(),
+                },
+            ),
+            GenericMessage::Registered(r) => r.encode(),
+        }
+    }
+
+    fn default_encoding() -> (Self::Type, Self::Value) {
+        (
+            Self::Type::NVTX_MESSAGE_UNKNOWN,
+            Self::Value {
+                ascii: std::ptr::null(),
+            },
+        )
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,15 @@
+pub mod event_argument;
+pub mod event_attributes;
+pub mod message;
+pub mod range;
+/// Test utilities for internal and integration tests.
+#[cfg(test)]
+pub mod test_utils;
+
+// Re-export commonly used items for convenience
+pub use event_argument::GenericEventArgument;
+pub use event_attributes::{encode_event_attributes, CategoryEncodable, GenericEventAttributes};
+pub use message::GenericMessage;
+pub use range::{LocalRangeLike, RangeLike};
+#[cfg(test)]
+pub use test_utils::TestUtils;

--- a/src/common/range.rs
+++ b/src/common/range.rs
@@ -1,0 +1,15 @@
+use crate::EventArgument;
+
+/// Common trait for range-like types that can be created from event arguments
+pub trait RangeLike {
+    type Id;
+
+    /// Create a new range from an event argument
+    fn new_from_arg(arg: impl Into<EventArgument>) -> Self;
+}
+
+/// Common trait for local range-like types
+pub trait LocalRangeLike {
+    /// Create a new local range from an event argument
+    fn new_from_arg(arg: impl Into<EventArgument>) -> Self;
+}

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -1,0 +1,120 @@
+#[cfg(test)]
+use crate::{common::CategoryEncodable, Color, Payload, TypeValueEncodable};
+use widestring::{WideCStr, WideCString};
+
+/// Utility struct for common test assertions and helpers.
+pub struct TestUtils;
+
+#[cfg(test)]
+impl TestUtils {
+    /// Assert that a message encodes to ASCII correctly
+    pub fn assert_message_ascii_encoding<T>(message: &T, expected_str: &str)
+    where
+        T: TypeValueEncodable<Type = nvtx_sys::MessageType, Value = nvtx_sys::MessageValue>,
+    {
+        let (t, v) = message.encode();
+        assert_eq!(t, nvtx_sys::MessageType::NVTX_MESSAGE_TYPE_ASCII);
+        let expected_cstr = std::ffi::CString::new(expected_str).unwrap();
+        unsafe {
+            assert!(
+                matches!(v, nvtx_sys::MessageValue{ ascii: p } if std::ffi::CStr::from_ptr(p) == expected_cstr.as_c_str())
+            );
+        }
+    }
+
+    /// Assert that a message encodes to Unicode correctly
+    pub fn assert_message_unicode_encoding<T>(message: &T, expected_str: &str)
+    where
+        T: TypeValueEncodable<Type = nvtx_sys::MessageType, Value = nvtx_sys::MessageValue>,
+    {
+        let (t, v) = message.encode();
+        assert_eq!(t, nvtx_sys::MessageType::NVTX_MESSAGE_TYPE_UNICODE);
+        unsafe {
+            assert!(
+                matches!(v, nvtx_sys::MessageValue{ unicode: p } if WideCStr::from_ptr_str(p.cast()) == WideCString::from_str(expected_str).unwrap())
+            );
+        }
+    }
+
+    /// Assert that a color encodes correctly
+    pub fn assert_color_encoding(
+        color: &Color,
+        expected_r: u8,
+        expected_g: u8,
+        expected_b: u8,
+        expected_a: u8,
+    ) {
+        let (t, v) = color.encode();
+        assert_eq!(t, nvtx_sys::ColorType::NVTX_COLOR_ARGB);
+        assert_eq!(
+            v,
+            u32::from_be_bytes([expected_a, expected_r, expected_g, expected_b])
+        );
+    }
+
+    /// Assert that a category encodes correctly
+    pub fn assert_category_encoding<T>(category: &T, expected_id: u32)
+    where
+        T: CategoryEncodable,
+    {
+        let encoded_id = category.encode_id();
+        assert_eq!(encoded_id, expected_id);
+    }
+
+    /// Assert that domain string registration works correctly
+    pub fn assert_domain_string_registration(domain: &crate::Domain, name: &str) {
+        let registered = domain.register_string(name);
+        let registered2 = domain.register_string(name);
+        assert_eq!(registered, registered2); // Should be cached
+    }
+
+    /// Assert that domain category registration works correctly
+    pub fn assert_domain_category_registration(domain: &crate::Domain, name: &str) {
+        let registered = domain.register_category(name);
+        let registered2 = domain.register_category(name);
+        assert_eq!(registered, registered2); // Should be cached
+    }
+
+    /// Assert that a payload is an i32 and matches the expected value.
+    pub fn assert_payload_i32(payload: &Payload, expected: i32) {
+        match payload {
+            Payload::Int32(val) => assert_eq!(*val, expected),
+            _ => panic!("Expected Payload::Int32"),
+        }
+    }
+    /// Assert that a payload is a u32 and matches the expected value.
+    pub fn assert_payload_u32(payload: &Payload, expected: u32) {
+        match payload {
+            Payload::Uint32(val) => assert_eq!(*val, expected),
+            _ => panic!("Expected Payload::Uint32"),
+        }
+    }
+    /// Assert that a payload is an i64 and matches the expected value.
+    pub fn assert_payload_i64(payload: &Payload, expected: i64) {
+        match payload {
+            Payload::Int64(val) => assert_eq!(*val, expected),
+            _ => panic!("Expected Payload::Int64"),
+        }
+    }
+    /// Assert that a payload is a u64 and matches the expected value.
+    pub fn assert_payload_u64(payload: &Payload, expected: u64) {
+        match payload {
+            Payload::Uint64(val) => assert_eq!(*val, expected),
+            _ => panic!("Expected Payload::Uint64"),
+        }
+    }
+    /// Assert that a payload is a f32 and matches the expected value.
+    pub fn assert_payload_f32(payload: &Payload, expected: f32) {
+        match payload {
+            Payload::Float(val) => assert!((*val - expected).abs() < f32::EPSILON),
+            _ => panic!("Expected Payload::Float"),
+        }
+    }
+    /// Assert that a payload is a f64 and matches the expected value.
+    pub fn assert_payload_f64(payload: &Payload, expected: f64) {
+        match payload {
+            Payload::Double(val) => assert!((*val - expected).abs() < f64::EPSILON),
+            _ => panic!("Expected Payload::Double"),
+        }
+    }
+}

--- a/src/domain/category.rs
+++ b/src/domain/category.rs
@@ -1,4 +1,4 @@
-use crate::Domain;
+use crate::{common::CategoryEncodable, Domain};
 
 /// Represents a domain-owned category for use with mark and range grouping.
 ///
@@ -22,11 +22,13 @@ impl<'a> Category<'a> {
         Category { id, domain }
     }
 
-    pub(super) fn id(&self) -> u32 {
-        self.id
-    }
-
     pub(super) fn domain(&self) -> &Domain {
         self.domain
+    }
+}
+
+impl CategoryEncodable for Category<'_> {
+    fn encode_id(&self) -> u32 {
+        self.id
     }
 }

--- a/src/domain/event_argument.rs
+++ b/src/domain/event_argument.rs
@@ -1,4 +1,5 @@
 use super::{EventAttributes, Message};
+use crate::common::GenericEventArgument;
 
 /// Convenience wrapper for all valid argument types to ranges and marks.
 ///
@@ -6,19 +7,12 @@ use super::{EventAttributes, Message};
 /// * If [`EventArgument::Attributes`] is the active discriminator:
 ///   - If its [`EventAttributes`] only specifies a message, then message will be used.
 ///   - Otherwise, the existing [`EventAttributes`] will be used for the event.
-#[derive(Debug, Clone)]
-pub enum EventArgument<'a> {
-    /// Holds a Message.
-    Message(Message<'a>),
-    /// Holds an EventAttributes.
-    Attributes(EventAttributes<'a>),
-}
+pub type EventArgument<'a> = GenericEventArgument<Message<'a>, EventAttributes<'a>>;
 
 impl<'a, T: Into<EventAttributes<'a>>> From<T> for EventArgument<'a> {
     fn from(value: T) -> Self {
         match value.into() {
             EventAttributes {
-                domain: None,
                 category: None,
                 color: None,
                 message: Some(m),

--- a/src/domain/local_range.rs
+++ b/src/domain/local_range.rs
@@ -12,6 +12,10 @@ pub struct LocalRange<'a> {
 
 impl<'a> LocalRange<'a> {
     pub(super) fn new(arg: impl Into<EventArgument<'a>>, domain: &'a Domain) -> LocalRange<'a> {
+        LocalRange::new_from_arg_with_domain(arg, domain)
+    }
+
+    fn new_from_arg_with_domain(arg: impl Into<EventArgument<'a>>, domain: &'a Domain) -> Self {
         let arg = match arg.into() {
             EventArgument::Attributes(attr) => attr,
             EventArgument::Message(m) => domain.event_attributes_builder().message(m).build(),

--- a/src/domain/range.rs
+++ b/src/domain/range.rs
@@ -10,6 +10,10 @@ pub struct Range<'a> {
 
 impl<'a> Range<'a> {
     pub(super) fn new(arg: impl Into<EventArgument<'a>>, domain: &'a Domain) -> Range<'a> {
+        Range::new_from_arg_with_domain(arg, domain)
+    }
+
+    fn new_from_arg_with_domain(arg: impl Into<EventArgument<'a>>, domain: &'a Domain) -> Self {
         Range {
             id: domain.range_start(arg),
             domain,

--- a/src/event_argument.rs
+++ b/src/event_argument.rs
@@ -1,4 +1,4 @@
-use crate::{EventAttributes, Message};
+use crate::{common::GenericEventArgument, EventAttributes, Message};
 
 /// Convenience wrapper for all valid argument types to ranges and marks.
 ///
@@ -6,13 +6,7 @@ use crate::{EventAttributes, Message};
 /// * If [`EventArgument::Attributes`] is the active discriminator:
 ///   - If its [`EventAttributes`] only specifies a message, then message will be used.
 ///   - Otherwise, the existing [`EventAttributes`] will be used for the event.
-#[derive(Debug, Clone)]
-pub enum EventArgument {
-    /// Holds a Message.
-    Message(Message),
-    /// Holds an EventAttributes.
-    Attributes(EventAttributes),
-}
+pub type EventArgument = GenericEventArgument<Message, EventAttributes>;
 
 impl<T: Into<EventAttributes>> From<T> for EventArgument {
     fn from(value: T) -> Self {

--- a/src/event_attributes.rs
+++ b/src/event_attributes.rs
@@ -1,46 +1,19 @@
-use crate::{Category, Color, Message, Payload, TypeValueEncodable};
+use crate::{
+    common::event_attributes::GenericEventAttributesBuilder,
+    common::{encode_event_attributes, GenericEventAttributes},
+    Category, Message,
+};
 
 /// All attributes that are associated with marks and ranges.
-#[derive(Debug, Clone)]
-pub struct EventAttributes {
-    pub(super) category: Option<Category>,
-    pub(super) color: Option<Color>,
-    pub(super) message: Option<Message>,
-    pub(super) payload: Option<Payload>,
-}
+pub type EventAttributes = GenericEventAttributes<Category, Message>;
 
 impl EventAttributes {
     pub(super) fn encode(&self) -> nvtx_sys::EventAttributes {
-        let (color_type, color_value) = self
-            .color
-            .as_ref()
-            .map(Color::encode)
-            .unwrap_or_else(Color::default_encoding);
-        let (payload_type, payload_value) = self
-            .payload
-            .as_ref()
-            .map(Payload::encode)
-            .unwrap_or_else(Payload::default_encoding);
-        let cat = self.category.as_ref().map(|c| c.id).unwrap_or(0);
-        let emit = |(t, v)| nvtx_sys::EventAttributes {
-            version: nvtx_sys::NVTX_VERSION as u16,
-            size: 48,
-            category: cat,
-            colorType: color_type as i32,
-            color: color_value,
-            payloadType: payload_type as i32,
-            reserved0: 0,
-            payload: payload_value,
-            messageType: t as i32,
-            message: v,
-        };
-        // this is separated as a callable since we need encode() to outlive the call to emit
-        emit(
-            self.message
-                .as_ref()
-                .map(Message::encode)
-                .unwrap_or_else(Message::default_encoding),
-        )
+        encode_event_attributes(&self.category, &self.color, &self.message, &self.payload)
+    }
+
+    pub fn builder() -> GenericEventAttributesBuilder<Category, Message> {
+        GenericEventAttributesBuilder::default()
     }
 }
 
@@ -55,106 +28,15 @@ impl<T: Into<Message>> From<T> for EventAttributes {
     }
 }
 
-/// Builder to facilitate easier construction of [`EventAttributes`].
-///
-/// ```
-/// let cat = nvtx::Category::new("Category1");
-///
-/// let attr = nvtx::EventAttributesBuilder::default()
-///                .category(cat)
-///                .color([20, 192, 240])
-///                .payload(3.141592)
-///                .message("Hello")
-///                .build();
-/// ```
-#[derive(Debug, Clone, Default)]
-pub struct EventAttributesBuilder {
-    pub(super) category: Option<Category>,
-    pub(super) color: Option<Color>,
-    pub(super) payload: Option<Payload>,
-    pub(super) message: Option<Message>,
-}
-
-impl EventAttributesBuilder {
-    /// Update the builder's held [`Category`].
-    ///
-    /// ```
-    /// let cat = nvtx::Category::new("Category1");
-    /// let builder = nvtx::EventAttributesBuilder::default();
-    /// // ...
-    /// let builder = builder.category(cat);
-    /// ```
-    pub fn category(mut self, category: Category) -> EventAttributesBuilder {
-        self.category = Some(category);
-        self
-    }
-
-    /// Update the builder's held [`Color`]. See [`Color`] for valid conversions.
-    ///
-    /// ```
-    /// let builder = nvtx::EventAttributesBuilder::default();
-    /// // ...
-    /// let builder = builder.color([255, 255, 255]);
-    /// ```
-    pub fn color(mut self, color: impl Into<Color>) -> EventAttributesBuilder {
-        self.color = Some(color.into());
-        self
-    }
-
-    /// Update the builder's held [`Payload`]. See [`Payload`] for valid conversions.
-    ///
-    /// ```
-    /// let builder = nvtx::EventAttributesBuilder::default();
-    /// // ...
-    /// let builder = builder.payload(3.1415926535);
-    /// ```
-    pub fn payload(mut self, payload: impl Into<Payload>) -> EventAttributesBuilder {
-        self.payload = Some(payload.into());
-        self
-    }
-
-    /// Update the the builder's held [`Message`]. See [`Message`] for valid conversions.
-    ///
-    /// ```
-    /// let builder = nvtx::EventAttributesBuilder::default();
-    /// // ...
-    /// let builder = builder.message("test");
-    /// ```
-    pub fn message(mut self, message: impl Into<Message>) -> EventAttributesBuilder {
-        self.message = Some(message.into());
-        self
-    }
-
-    /// Construct an [`EventAttributes`] from the builder's held state.
-    ///
-    /// ```
-    /// let cat = nvtx::Category::new("Category1");
-    /// let attr = nvtx::EventAttributesBuilder::default()
-    ///                 .message("Example Range")
-    ///                 .color([224, 192, 128])
-    ///                 .category(cat)
-    ///                 .payload(1234567)
-    ///                 .build();
-    /// ```
-    pub fn build(self) -> EventAttributes {
-        EventAttributes {
-            category: self.category,
-            color: self.color,
-            payload: self.payload,
-            message: self.message,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::ffi::CString;
 
-    use crate::{register_category, Color, EventAttributesBuilder, Message, Payload};
+    use crate::{register_category, Color, EventAttributes, Message, Payload};
 
     #[test]
     fn test_builder_color() {
-        let builder = EventAttributesBuilder::default();
+        let builder = EventAttributes::builder();
         let color = Color::new(0x11, 0x22, 0x44, 0x88);
         let attr = builder.color(color).build();
         assert!(matches!(attr.color, Some(c) if c == color));
@@ -162,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_builder_category() {
-        let builder = EventAttributesBuilder::default();
+        let builder = EventAttributes::builder();
         let cat = register_category("cat");
         let attr = builder.category(cat).build();
         assert!(matches!(attr.category, Some(c) if c == cat));
@@ -170,31 +52,30 @@ mod tests {
 
     #[test]
     fn test_builder_payload() {
-        let builder = EventAttributesBuilder::default();
-        let attr = builder.clone().payload(1_i32).build();
+        let attr = EventAttributes::builder().payload(1_i32).build();
         assert!(matches!(attr.payload, Some(Payload::Int32(i)) if i == 1_i32));
-        let attr = builder.clone().payload(2_u32).build();
+        let attr = EventAttributes::builder().payload(2_u32).build();
         assert!(matches!(attr.payload, Some(Payload::Uint32(i)) if i == 2_u32));
-        let attr = builder.clone().payload(1_i64).build();
+        let attr = EventAttributes::builder().payload(1_i64).build();
         assert!(matches!(attr.payload, Some(Payload::Int64(i)) if i == 1_i64));
-        let attr = builder.clone().payload(2_u64).build();
+        let attr = EventAttributes::builder().payload(2_u64).build();
         assert!(matches!(attr.payload, Some(Payload::Uint64(i)) if i == 2_u64));
-        let attr = builder.clone().payload(1.0_f32).build();
+        let attr = EventAttributes::builder().payload(1.0_f32).build();
         assert!(matches!(attr.payload, Some(Payload::Float(i)) if i == 1.0_f32));
-        let attr = builder.clone().payload(2.0_f64).build();
+        let attr = EventAttributes::builder().payload(2.0_f64).build();
         assert!(matches!(attr.payload, Some(Payload::Double(i)) if i == 2.0_f64));
     }
 
     #[test]
     fn test_builder_message() {
-        let builder = EventAttributesBuilder::default();
+        let builder = EventAttributes::builder();
         let string = "This is a message";
         let attr = builder.message(string).build();
         assert!(
             matches!(attr.message, Some(Message::Unicode(s)) if s.to_string().unwrap() == string)
         );
 
-        let builder = EventAttributesBuilder::default();
+        let builder = EventAttributes::builder();
         let cstring = CString::new("This is a message").unwrap();
         let attr = builder.message(cstring.clone()).build();
         assert!(matches!(attr.message, Some(Message::Ascii(s)) if s == cstring));

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,27 +1,11 @@
-use crate::{Str, TypeValueEncodable};
-use std::ffi::CString;
-use widestring::WideCString;
+use crate::common::GenericMessage;
+use crate::TypeValueEncodable;
 
 /// Represents a message for use within events and ranges.
 ///
 /// * [`Message::Ascii`] is the discriminator for ASCII C strings
 /// * [`Message::Unicode`] is the discriminator for Rust strings and wide C strings
-#[derive(Debug, Clone)]
-pub enum Message {
-    /// An owned ASCII string.
-    Ascii(CString),
-    /// An owned Unicode string.
-    Unicode(WideCString),
-}
-
-impl<T: Into<Str>> From<T> for Message {
-    fn from(value: T) -> Self {
-        match value.into() {
-            Str::Ascii(s) => Message::Ascii(s),
-            Str::Unicode(s) => Message::Unicode(s),
-        }
-    }
-}
+pub type Message = GenericMessage<()>;
 
 impl TypeValueEncodable for Message {
     type Type = nvtx_sys::MessageType;
@@ -39,6 +23,9 @@ impl TypeValueEncodable for Message {
                     unicode: s.as_ptr().cast(),
                 },
             ),
+            Message::Registered(_) => {
+                unreachable!("Registered strings are not valid in the global context")
+            }
         }
     }
 
@@ -55,9 +42,9 @@ impl TypeValueEncodable for Message {
 #[cfg(test)]
 mod tests {
     use super::Message;
-    use crate::TypeValueEncodable;
-    use std::ffi::{CStr, CString};
-    use widestring::{WideCStr, WideCString};
+    use crate::common::TestUtils;
+    use std::ffi::CString;
+    use widestring::WideCString;
 
     #[test]
     fn test_message_ascii() {
@@ -78,13 +65,7 @@ mod tests {
     fn test_encode_ascii() {
         let cstr = CString::new("hello").unwrap();
         let m = Message::Ascii(cstr.clone());
-        let (t, v) = m.encode();
-        assert_eq!(t, nvtx_sys::MessageType::NVTX_MESSAGE_TYPE_ASCII);
-        unsafe {
-            assert!(
-                matches!(v, nvtx_sys::MessageValue{ ascii: p } if CStr::from_ptr(p) == cstr.as_c_str())
-            );
-        }
+        TestUtils::assert_message_ascii_encoding(&m, "hello");
     }
 
     #[test]
@@ -92,12 +73,6 @@ mod tests {
         let s = "hello";
         let wstr = WideCString::from_str(s).unwrap();
         let m = Message::Unicode(wstr.clone());
-        let (t, v) = m.encode();
-        assert_eq!(t, nvtx_sys::MessageType::NVTX_MESSAGE_TYPE_UNICODE);
-        unsafe {
-            assert!(
-                matches!(v, nvtx_sys::MessageValue{ unicode: p } if WideCStr::from_ptr_str(p.cast()) == wstr)
-            )
-        };
+        TestUtils::assert_message_unicode_encoding(&m, "hello");
     }
 }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -103,66 +103,37 @@ impl TypeValueEncodable for Payload {
 
 #[cfg(test)]
 mod tests {
-    use crate::TypeValueEncodable;
-
     use super::Payload;
+    use crate::common::TestUtils;
 
     #[test]
-    fn test_encode_i32() {
-        let p = Payload::Int32(i32::MAX);
-        let (t, v) = p.encode();
-        assert_eq!(t, nvtx_sys::PayloadType::NVTX_PAYLOAD_TYPE_INT32);
-        unsafe { assert!(matches!(v, nvtx_sys::PayloadValue { iValue: v } if v == i32::MAX)) };
+    fn test_payload_int32() {
+        let payload = Payload::Int32(i32::MAX);
+        TestUtils::assert_payload_i32(&payload, i32::MAX);
     }
-
     #[test]
-    fn test_encode_u32() {
-        let p = Payload::Uint32(u32::MAX);
-        let (t, v) = p.encode();
-        assert_eq!(t, nvtx_sys::PayloadType::NVTX_PAYLOAD_TYPE_UNSIGNED_INT32);
-        unsafe { assert!(matches!(v, nvtx_sys::PayloadValue { uiValue: v } if v == u32::MAX)) };
+    fn test_payload_uint32() {
+        let payload = Payload::Uint32(u32::MAX);
+        TestUtils::assert_payload_u32(&payload, u32::MAX);
     }
-
     #[test]
-    fn test_encode_i64() {
-        let p = Payload::Int64(i64::MAX);
-        let (t, v) = p.encode();
-        assert_eq!(t, nvtx_sys::PayloadType::NVTX_PAYLOAD_TYPE_INT64);
-        unsafe { assert!(matches!(v, nvtx_sys::PayloadValue { llValue: v } if v == i64::MAX)) };
+    fn test_payload_int64() {
+        let payload = Payload::Int64(i64::MAX);
+        TestUtils::assert_payload_i64(&payload, i64::MAX);
     }
-
     #[test]
-    fn test_encode_u64() {
-        let p = Payload::Uint64(u64::MAX);
-        let (t, v) = p.encode();
-        assert_eq!(t, nvtx_sys::PayloadType::NVTX_PAYLOAD_TYPE_UNSIGNED_INT64);
-        unsafe { assert!(matches!(v, nvtx_sys::PayloadValue { ullValue: v } if v == u64::MAX)) };
+    fn test_payload_uint64() {
+        let payload = Payload::Uint64(u64::MAX);
+        TestUtils::assert_payload_u64(&payload, u64::MAX);
     }
-
     #[test]
-    fn test_encode_float() {
-        let p = Payload::Float(std::f32::consts::PI);
-        let (t, v) = p.encode();
-        assert_eq!(t, nvtx_sys::PayloadType::NVTX_PAYLOAD_TYPE_FLOAT);
-        unsafe {
-            assert!(matches!(v, nvtx_sys::PayloadValue { fValue: v } if v == std::f32::consts::PI))
-        };
+    fn test_payload_float() {
+        let payload = Payload::Float(std::f32::consts::PI);
+        TestUtils::assert_payload_f32(&payload, std::f32::consts::PI);
     }
-
     #[test]
-    fn test_encode_double() {
-        let p = Payload::Double(std::f64::consts::E);
-        let (t, v) = p.encode();
-        assert_eq!(t, nvtx_sys::PayloadType::NVTX_PAYLOAD_TYPE_DOUBLE);
-        unsafe {
-            assert!(matches!(v, nvtx_sys::PayloadValue { dValue: v } if v == std::f64::consts::E))
-        };
-    }
-
-    #[test]
-    fn test_encode_defaults() {
-        let (t, v) = Payload::default_encoding();
-        assert_eq!(t, nvtx_sys::PayloadType::NVTX_PAYLOAD_UNKNOWN);
-        unsafe { assert!(matches!(v, nvtx_sys::PayloadValue { ullValue: v } if v == 0)) };
+    fn test_payload_double() {
+        let payload = Payload::Double(std::f64::consts::E);
+        TestUtils::assert_payload_f64(&payload, std::f64::consts::E);
     }
 }


### PR DESCRIPTION
* Bumps library version to 0.2.0 due to breaking API changes
* Hoist general logic to `common`
* Prefer `EventAttributes::builder()` to `EventAttributesBuilder::default()`