### PR TITLE
Update licensing to Apache-2.0 WITH LLVM-exception

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "NVIDIA NVTX bindings for Rust"
 repository = "https://github.com/voltrondata/nvtx-rs"
 readme = "README.md"
 publish = false
-license = "Apache-2.0"
+license = "Apache-2.0 WITH LLVM-exception"
 
 [package]
 name = "nvtx"

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+==============================================================================
+nvtx-rs is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -199,3 +203,20 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.


### PR DESCRIPTION
I am creating this pull request to propose the amendment of nvtx-rs' licensing to include the LLVM Exceptions to the Apache 2.0 License, to synchronize it with core NVTX.

This is important for use with codebases licensed as GPL-2.0-only, such as the Linux kernel and some open-source game engines. Without the exceptions, the terms of Apache 2.0 conflict with the GPLv2 so that the combination of code under the two licenses is incompatible.

It also allows the user to make use of NVTX without any additional burden of including that fact in their documentation, similar to LLVM libc and libc++. This is part of NVTX's design goal to have the absolute minimum overhead and barrier to entry.

Note: This change requires approval and sign-off before it takes effect.